### PR TITLE
fix warning

### DIFF
--- a/Joypad.qml
+++ b/Joypad.qml
@@ -62,7 +62,7 @@ Item {
                 return (value < min) ? min : (value > max) ? max : value
             }
 
-            onPressed: {
+            onPressed: (touchPoints) => {
                 for (var i = 0; i<touchPoints.length; i++)
                 {
                     var pos = Qt.vector2d(touchPoints[i].x, touchPoints[i].y)
@@ -79,7 +79,7 @@ Item {
                 }
             }
 
-            onReleased: {
+            onReleased: (touchPoints) => {
                 for (var i = 0; i<touchPoints.length; i++)
                 {
                     if (touchPoints[i].pointId == validPoint.pointId)
@@ -91,7 +91,7 @@ Item {
                 }
             }
 
-            onUpdated: {
+            onUpdated: (touchPoints) => {
                 for (var i = 0; i<touchPoints.length; i++)
                 {
                     if (touchPoints[i].pointId == validPoint.pointId)

--- a/Joypad.qml
+++ b/Joypad.qml
@@ -82,7 +82,7 @@ Item {
             onReleased: (touchPoints) => {
                 for (var i = 0; i<touchPoints.length; i++)
                 {
-                    if (touchPoints[i].pointId == validPoint.pointId)
+                    if (touchPoints[i].pointId === validPoint.pointId)
                     {
                         validPoint = 0
                         if (horizontalAnimation) xAnimation.start()
@@ -94,7 +94,7 @@ Item {
             onUpdated: (touchPoints) => {
                 for (var i = 0; i<touchPoints.length; i++)
                 {
-                    if (touchPoints[i].pointId == validPoint.pointId)
+                    if (touchPoints[i].pointId === validPoint.pointId)
                     {
                         // slightly adjust the thumb towards the pointer
                         thumb.offset = thumb.offset.times(0.98)


### PR DESCRIPTION
Small fixes to silence the warning `Parameter "touchPoints" is not declared. Injection of parameters into signal handlers is deprecated. Use JavaScript functions with formal parameters instead.` and one related to the comparison operator in Qt 6.